### PR TITLE
added destructors with release call to physX objects

### DIFF
--- a/include/Aggregate.h
+++ b/include/Aggregate.h
@@ -17,6 +17,10 @@ public:
             BasePhysxPointer<physx::PxAggregate>(
                     Physics::get_physics()->createAggregate(max_size, enable_self_collision)) {}
 
+    ~Aggregate() {
+		get_physx_ptr()->release();
+	}
+
     explicit Aggregate(physx::PxAggregate *physxPtr) : BasePhysxPointer<physx::PxAggregate>(physxPtr) {}
 
     void add_actor(RigidActor actor) {

--- a/include/D6Joint.h
+++ b/include/D6Joint.h
@@ -18,6 +18,10 @@ public:
                                                       a1.get_physx_ptr(), local_pose1)) {
         get_physx_ptr()->setConstraintFlag(physx::PxConstraintFlag::eENABLE_EXTENDED_LIMITS, true);
     }
+	
+	~D6Joint() {
+		get_physx_ptr()->release();
+	}
 
     void set_motion(physx::PxD6Axis::Enum axis, physx::PxD6Motion::Enum type) {
         get_physx_ptr()->setMotion(axis, type);

--- a/include/Material.h
+++ b/include/Material.h
@@ -19,6 +19,10 @@ public:
     Material(float static_friction, float dynamic_friction, float restitution) :
             BasePhysxPointer(Physics::get_physics()->createMaterial(static_friction, dynamic_friction, restitution)) {
     }
+	
+	~Material() {
+		get_physx_ptr()->release();
+	}
 
     explicit Material(physx::PxMaterial *pref) : BasePhysxPointer<physx::PxMaterial>(pref) {}
 

--- a/include/RigidActor.h
+++ b/include/RigidActor.h
@@ -16,6 +16,10 @@ class RigidActor : public BasePhysxPointer<physx::PxRigidActor> {
 public:
     explicit RigidActor(physx::PxRigidActor *physxPtr) : BasePhysxPointer(physxPtr) {}
 
+    ~RigidActor() {
+		get_physx_ptr()->release();
+	}
+
     auto get_global_pose() {
         return get_physx_ptr()->getGlobalPose();
     }

--- a/include/RigidDynamic.h
+++ b/include/RigidDynamic.h
@@ -21,6 +21,10 @@ private:
 public:
     RigidDynamic() : RigidDynamic(Physics::get_physics()->createRigidDynamic(physx::PxTransform(physx::PxIdentity))) {
     }
+	
+	~RigidDynamic() {
+		get_physx_ptr()->release();
+	}
 
     explicit RigidDynamic(physx::PxRigidDynamic *physxPtr) :
             RigidActor(reinterpret_cast<RigidActor::type_physx *>(physxPtr)) {
@@ -88,8 +92,7 @@ public:
 
     void set_kinematic_target(const physx::PxTransform &pose) {
         get_dyn_ptr()->setKinematicTarget(pose);
-    }
-
+    }	
 };
 
 #endif //SIM_PHYSX_RIGIDDYNAMIC_H

--- a/include/RigidStatic.h
+++ b/include/RigidStatic.h
@@ -24,6 +24,10 @@ public:
     explicit RigidStatic(physx::PxRigidStatic *physxPtr) :
             RigidActor(reinterpret_cast<RigidActor::type_physx *>(physxPtr)) {
     }
+	
+	~RigidStatic() {
+		get_physx_ptr()->release();
+	}
 
     static RigidStatic create_plane(Material mat, float nx, float ny, float nz, float distance) {
         return RigidStatic(physx::PxCreatePlane(*Physics::get_physics(), physx::PxPlane(nx, ny, nz, distance),

--- a/include/Scene.h
+++ b/include/Scene.h
@@ -43,6 +43,10 @@ public:
 
         set_physx_ptr(Physics::get().physics->createScene(sceneDesc));
     }
+	
+	~Scene() {
+		get_physx_ptr()->release();
+	}
 
     /** @brief Simulate scene for given amount of time dt and fetch results with blocking. */
     void simulate(float dt) {

--- a/include/Shape.h
+++ b/include/Shape.h
@@ -24,6 +24,10 @@ class Shape : public BasePhysxPointer<physx::PxShape> {
 public:
     explicit Shape(physx::PxShape *pref) : BasePhysxPointer<physx::PxShape>(pref) {}
 
+	~Shape() {
+		get_physx_ptr()->release();
+	}
+	
     void set_flag(physx::PxShapeFlag::Enum flag, bool value) {
         get_physx_ptr()->setFlag(flag, value);
     }


### PR DESCRIPTION
I observed increasing ram usage when creating and destroying scenes within a loop in python. Checking the code I could not find any release calls for the cpp PhysX objects that were created within the respective classes.
Afterwards the Memory usage for my loop-test looked alright. 

Please check if these changes make any sense and work in the context of having multiple python references to the same PyPhysx objects. 